### PR TITLE
feat: show admin edit link on taibol /data page when logged in

### DIFF
--- a/app/blueprints/frontpage.py
+++ b/app/blueprints/frontpage.py
@@ -11,6 +11,7 @@ from flask import (
     url_for,
     current_app,
 )
+from flask_login import current_user
 from jinja2.exceptions import TemplateNotFound
 from sqlalchemy import (
     desc,
@@ -342,10 +343,12 @@ def data_search(lang_code):
     if current_app.config['WEB_ENV'] != 'dev':
         if api_url[0:5] == 'http:':
             api_url = api_url.replace('http:', 'https:')
+    # logged-in admin users get inline edit links into the admin record form
+    is_admin = current_user.is_authenticated
     try:
-        return render_template(f'sites/{g.site.name}/data-search.html', options=options, SEARCH_API_URL=api_url)
+        return render_template(f'sites/{g.site.name}/data-search.html', options=options, SEARCH_API_URL=api_url, is_admin=is_admin)
     except TemplateNotFound:
-        return render_template('data-search.html', options=options, SEARCH_API_URL=api_url)
+        return render_template('data-search.html', options=options, SEARCH_API_URL=api_url, is_admin=is_admin)
 
 @frontpage.route('/api/taxon-tree/trees')
 def taxon_tree_list():

--- a/app/static/sites/taibol/js/data-search.js
+++ b/app/static/sites/taibol/js/data-search.js
@@ -91,6 +91,16 @@ $(window).keydown(function(event){
           italicFont.textContent = x.species_name;
           link.appendChild(italicFont);
           td[0].appendChild(link);
+          // admin-only inline edit link into the admin record form
+          if (window.IS_ADMIN && item.record_id) {
+            let editLink = document.createElement('a');
+            editLink.href = `/admin/records/r${item.record_id}`;
+            editLink.target = '_blank';
+            editLink.className = 'admin-edit-link';
+            editLink.textContent = '編輯';
+            editLink.style.marginLeft = '0.5em';
+            td[0].appendChild(editLink);
+          }
           td[1].textContent = (params.get('collection') === 'material_sample') ? x.unit_id : x.voucher_id;
           td[2].innerHTML = `${x.kingdom_name_zh}${x.kingdom_name}`;
           td[3].innerHTML = `${x.phylum_name_zh}${x.phylum_name}`;

--- a/app/templates/sites/taibol/data-search.html
+++ b/app/templates/sites/taibol/data-search.html
@@ -5,6 +5,7 @@
 {% endblock %}
 
 {% block script %}
+<script>window.IS_ADMIN = {{ is_admin | default(false) | tojson }};</script>
 <script src="{{ url_for('static', filename='sites/taibol/js/data-search.js' ) }}"/></script>
 {% endblock %}
 


### PR DESCRIPTION
Pass current_user.is_authenticated as is_admin to the data-search template, expose it to JS as window.IS_ADMIN, and render an inline 編輯 link per result to /admin/records/r<record_id> for logged-in admin users. Authorization is still enforced by the @login_required record_form route.