### PR TITLE
feat: add direct page-jump input to taibol /data pagination

### DIFF
--- a/app/static/sites/taibol/js/data-search.js
+++ b/app/static/sites/taibol/js/data-search.js
@@ -6,6 +6,9 @@
   let resultBody = document.getElementById('result-body');
   let resultTemplate = document.getElementById('result-template');
   let resultPagination = document.getElementById('result-pagination');
+  let pageJumpInput = document.getElementById('page-jump-input');
+  let pageJumpButton = document.getElementById('page-jump-button');
+  let pageJumpTotal = document.getElementById('page-jump-total');
   let pagination = {
     page: 1,
     numPerPage: 20,
@@ -28,6 +31,28 @@
     //console.log(inputElem.value);
     goSearch();
   };
+  const goToPage = () => {
+    let target = parseInt(pageJumpInput.value, 10);
+    if (isNaN(target)) {
+      return;
+    }
+    // clamp to valid range so out-of-bounds input can't break the query
+    target = Math.max(1, Math.min(target, pagination.numPages));
+    pageJumpInput.value = target;
+    if (target === pagination.page) {
+      return;
+    }
+    pagination.page = target;
+    goSearch();
+  };
+  pageJumpButton.onclick = goToPage;
+  pageJumpInput.addEventListener('keydown', (event) => {
+    if (event.keyCode === 13) {
+      event.preventDefault();
+      event.stopPropagation();
+      goToPage();
+    }
+  });
 $(window).keydown(function(event){
     if(event.keyCode == 13) {
       event.preventDefault();
@@ -132,6 +157,11 @@ $(window).keydown(function(event){
         //console.log(pagination);
         resultPagination.innerHTML = '';
         let numPages = Math.ceil(result.total/pagination.numPerPage);
+        // expose for the page-jump control
+        pagination.numPages = numPages;
+        pageJumpTotal.textContent = numPages;
+        pageJumpInput.max = numPages;
+        pageJumpInput.value = pagination.page;
         let showList = [];
         showList.push({
           label: '&lt;',

--- a/app/templates/sites/taibol/data-search.html
+++ b/app/templates/sites/taibol/data-search.html
@@ -143,6 +143,13 @@
       </ul>
     </nav>
 
+    <div class="d-flex justify-content-center align-items-center mb-3" id="page-jump" style="gap: .5rem;">
+      <label for="page-jump-input" class="mb-0">前往第</label>
+      <input type="number" min="1" id="page-jump-input" class="form-control" style="width: 5rem;" aria-label="頁碼">
+      <label class="mb-0">頁 / 共 <span id="page-jump-total">1</span> 頁</label>
+      <button type="button" id="page-jump-button" class="btn btn-outline-secondary btn-sm">前往</button>
+    </div>
+
 <template id="result-template">
   <tr align="center">
     <td scope="row"></td>


### PR DESCRIPTION
Lets users enter a page number and jump directly instead of stepping through windowed pagination links. Input is clamped to [1, numPages]; Enter on the field stops propagation so the global keydown handler doesn't fire a stale search.