### PR TITLE
feat: server-side taxon search in data-search filters

### DIFF
--- a/app/templates/_inc_filters_drawer.html
+++ b/app/templates/_inc_filters_drawer.html
@@ -28,6 +28,7 @@
       <div>
         <h4 class="font-semibold mb-2">{{ _('物種') }}{# Taxonomy #}</h4>
         <div class="space-y-2">
+          {{ filter_input('taxon', _('學名 (不限階層)'), 'combobox') }}
           {{ filter_input('family', _('科名'), 'combobox', options=options.family) }}
           {{ filter_input('genus', _('屬名'), 'combobox') }}
           {{ filter_input('species', _('種名'), 'combobox') }}
@@ -103,6 +104,7 @@
 
      const clearFilterButton = document.getElementById('clear-filter-btn');
      clearFilterButton.onclick = (e) => {
+       resetTomSelectOptions(taxonSelect);
        resetTomSelectOptions(speciesSelect);
        resetTomSelectOptions(genusSelect);
        resetTomSelectOptions(familySelect);
@@ -130,42 +132,77 @@
          element.addOptions(options);
        }
      };
+     // Remote taxon search: filter server-side by keyword, scoped to the
+     // selected parent. Avoids loading entire (and silently truncated) lists
+     // client-side. range is small because the backend does the filtering.
+     const loadTaxa = (rank, getParentId) => (query, callback) => {
+       // tree_id 1 = accepted plant taxonomy tree (excludes other trees' duplicates)
+       const filtr = { rank: rank, q: query, tree_id: 1 };
+       const parentId = getParentId();
+       if (parentId) {
+         filtr.parent_id = parentId;
+       }
+       const url = `/api/v1/taxa?filter=${JSON.stringify(filtr)}&range=${JSON.stringify([0, 50])}`;
+       fetchData(url)
+         .then(res => callback((res.data || []).map(x => ({ value: x.id, text: x.display_name }))))
+         .catch(() => callback());
+     };
+     // Universal taxon search across ALL ranks (no rank/parent constraint).
+     // Independent of the family→genus→species cascade below.
+     let taxonSelect = new TomSelect("#filter-taxon", {
+       valueField: 'value',
+       labelField: 'text',
+       searchField: 'text',
+       maxItems: 1,
+       preload: 'focus',
+       shouldLoad: () => true,
+       load: (query, callback) => {
+         const url = `/api/v1/taxa?filter=${JSON.stringify({ q: query, tree_id: 1 })}&range=${JSON.stringify([0, 50])}`;
+         fetchData(url)
+           .then(res => callback((res.data || []).map(x => ({
+             value: x.id,
+             text: x.rank ? `${x.display_name} [${x.rank}]` : x.display_name,
+           }))))
+           .catch(() => callback());
+       }
+     });
      let familySelect = new TomSelect("#filter-family", {
        maxOptions: null,
        maxItems: 1,
        sortField: {
 	 field: "text",
 	 direction: "asc"
-       }, onChange: async (value) => {
-         let options = [];
-         if (value) {
-           options = await fetchOptions('/api/v1/taxa', {rank: 'genus', parent_id: value});
-         }
-         resetTomSelectOptions(genusSelect, options);
+       }, onChange: () => {
+         // parent changed: drop downstream selections so they re-search the new
+         // scope. clearOptions() already resets the load cache; resetting the
+         // 'preloaded' flag lets focus re-preload the new parent's list.
+         resetTomSelectOptions(genusSelect);
          resetTomSelectOptions(speciesSelect);
+         genusSelect.wrapper.classList.remove('preloaded');
+         speciesSelect.wrapper.classList.remove('preloaded');
        }
      });
      let genusSelect = new TomSelect("#filter-genus", {
-       maxOptions: null,
+       valueField: 'value',
+       labelField: 'text',
+       searchField: 'text',
        maxItems: 1,
-       sortField: {
-	 field: "text",
-	 direction: "asc"
-       }, onChange: async (value) => {
-         let options = [];
-         if (value) {
-           options = await fetchOptions('/api/v1/taxa', {rank: 'species', parent_id: value});
-         }
-         resetTomSelectOptions(speciesSelect, options);
+       preload: 'focus',
+       shouldLoad: () => true,
+       load: loadTaxa('genus', () => familySelect.getValue()),
+       onChange: () => {
+         resetTomSelectOptions(speciesSelect);
+         speciesSelect.wrapper.classList.remove('preloaded');
        }
      });
      let speciesSelect = new TomSelect("#filter-species", {
-       maxOptions: null,
+       valueField: 'value',
+       labelField: 'text',
+       searchField: 'text',
        maxItems: 1,
-       sortField: {
-	 field: "text",
-	 direction: "asc"
-       }
+       preload: 'focus',
+       shouldLoad: () => true,
+       load: loadTaxa('species', () => genusSelect.getValue())
      });
      let collectorSelect = new TomSelect('#filter-collector', {
        valueField: 'id',
@@ -241,6 +278,7 @@
      let adm3Select = new TomSelect('#filter-adm3', {});
 
      window.filterSelects = {
+       taxon: taxonSelect,
        family: familySelect,
        genus: genusSelect,
        species: speciesSelect,

--- a/app/templates/data-search.html
+++ b/app/templates/data-search.html
@@ -232,7 +232,7 @@
      let data = {};
      for (const [key, value] of formData) {
        if (value) {
-         if (['species', 'genus', 'family', 'adm1', 'adm2', 'adm3'].indexOf(key) < 0) {
+         if (['taxon', 'species', 'genus', 'family', 'adm1', 'adm2', 'adm3'].indexOf(key) < 0) {
            data[key] = value;
          }
        }
@@ -241,8 +241,8 @@
      if (col) {
       data.collector_id = col;
      }
-     // taxon_id
-     const taxa = ['species', 'genus', 'family'];
+     // taxon_id — universal taxon (any rank) takes precedence, then the cascade
+     const taxa = ['taxon', 'species', 'genus', 'family'];
      for(let i=0; i<taxa.length; i++) {
        if (formData.has(taxa[i]) && formData.get(taxa[i])) {
          data.taxon_id = formData.get(taxa[i]);
@@ -383,16 +383,25 @@
        months.forEach(m => sel.collect_month.addItem(m, true));
      }
 
+     // universal taxon (any rank)
+     if (params.has('taxon') && sel.taxon && fetchOpts) {
+       const taxonId = params.get('taxon');
+       const opts = await fetchOpts('/api/v1/taxa', {id: [parseInt(taxonId)]});
+       sel.taxon.clearOptions();
+       sel.taxon.addOptions(opts);
+       sel.taxon.setValue(taxonId, true);
+     }
+
      // taxonomy cascade: family → genus → species
      if (params.has('family') && sel.family) {
        sel.family.setValue(params.get('family'), true);
        if (params.has('genus') && fetchOpts) {
-         const genusOpts = await fetchOpts('/api/v1/taxa', {rank: 'genus', parent_id: params.get('family')});
+         const genusOpts = await fetchOpts('/api/v1/taxa', {rank: 'genus', parent_id: params.get('family'), tree_id: 1});
          sel.genus.clearOptions();
          sel.genus.addOptions(genusOpts);
          sel.genus.setValue(params.get('genus'), true);
          if (params.has('species')) {
-           const speciesOpts = await fetchOpts('/api/v1/taxa', {rank: 'species', parent_id: params.get('genus')});
+           const speciesOpts = await fetchOpts('/api/v1/taxa', {rank: 'species', parent_id: params.get('genus'), tree_id: 1});
            sel.species.clearOptions();
            sel.species.addOptions(speciesOpts);
            sel.species.setValue(params.get('species'), true);


### PR DESCRIPTION
Genus/species comboboxes loaded up to 500 rows per parent and filtered client-side, silently truncating large genera. Switch them to TomSelect remote `load` (range=[0,50]), pushing keyword + parent scope to the backend, mirroring the existing collector/country selects.

Also:
- Add a universal taxon search above family that searches all ranks (no rank/parent constraint), tagging results with [rank]; its selection feeds taxon_id with top precedence over the cascade.
- Constrain all taxon queries to tree_id=1 (accepted plant tree) to drop cross-tree duplicates.
- Restore taxon/genus/species from URL params accordingly.