### PR TITLE
perf: add missing FK indexes on taxon_relation and unit

### DIFF
--- a/alembic/versions/d9e0f1a2b3c4_add_missing_fk_indexes.py
+++ b/alembic/versions/d9e0f1a2b3c4_add_missing_fk_indexes.py
@@ -1,0 +1,59 @@
+"""add missing FK indexes on taxon_relation and unit
+
+Revision ID: d9e0f1a2b3c4
+Revises: f7e8d9c0a1b2
+Create Date: 2026-07-31 04:10:00.000000
+
+PostgreSQL does not create indexes for foreign keys automatically, so these
+three FK columns were only ever reachable by sequential scan:
+
+  - taxon_relation.parent_id
+  - taxon_relation.child_id
+  - unit.record_id
+
+taxon_relation is a closure table: every ancestry walk filters on parent_id or
+child_id. On production this produced 13.1M sequential scans against 709k rows
+(vs 608k index scans, a number that never moved), which pinned the DB CPU and
+exhausted the instance's burst credits.
+
+Built with CREATE INDEX CONCURRENTLY so the build takes no write lock -- `unit`
+is written continuously by the admin edit path. That requires running outside a
+transaction, hence the autocommit_block. statement_timeout is cleared for the
+session because production sets a 30s cap that would otherwise kill the build
+partway and leave an INVALID index behind.
+"""
+from alembic import op
+
+
+revision = 'd9e0f1a2b3c4'
+down_revision = 'f7e8d9c0a1b2'
+branch_labels = None
+depends_on = None
+
+
+# (index name, table, column) -- names match SQLAlchemy's default
+# ix_<table>_<column> so autogenerate stays quiet about them.
+INDEXES = [
+    ('ix_taxon_relation_parent_id', 'taxon_relation', 'parent_id'),
+    ('ix_taxon_relation_child_id', 'taxon_relation', 'child_id'),
+    ('ix_unit_record_id', 'unit', 'record_id'),
+]
+
+
+def upgrade():
+    with op.get_context().autocommit_block():
+        op.execute('SET statement_timeout = 0')
+        for name, table, column in INDEXES:
+            # IF NOT EXISTS: some environments may already have these applied
+            # by hand during the incident.
+            op.execute(
+                f'CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} '
+                f'ON {table} ({column})'
+            )
+
+
+def downgrade():
+    with op.get_context().autocommit_block():
+        op.execute('SET statement_timeout = 0')
+        for name, _table, _column in INDEXES:
+            op.execute(f'DROP INDEX CONCURRENTLY IF EXISTS {name}')

--- a/app/models/collection.py
+++ b/app/models/collection.py
@@ -1346,7 +1346,7 @@ class Unit(Base, TimestampMixin, UpdateMixin):
 
     id = Column(Integer, primary_key=True)
     guid = Column(String(500))
-    record_id = Column(Integer, ForeignKey('record.id', ondelete='SET NULL'), nullable=True)
+    record_id = Column(Integer, ForeignKey('record.id', ondelete='SET NULL'), nullable=True, index=True)
     collection_id = Column(Integer, ForeignKey('collection.id', ondelete='SET NULL'), nullable=True, index=True)
     #last_editor = Column(String(500)) # link to user
 

--- a/app/models/taxon.py
+++ b/app/models/taxon.py
@@ -39,8 +39,8 @@ class TaxonRelation(Base):
     __tablename__ = 'taxon_relation'
 
     id = Column(Integer, primary_key=True)
-    parent_id = Column(Integer, ForeignKey('taxon.id', ondelete='SET NULL'))
-    child_id = Column(Integer, ForeignKey('taxon.id', ondelete='SET NULL'))
+    parent_id = Column(Integer, ForeignKey('taxon.id', ondelete='SET NULL'), index=True)
+    child_id = Column(Integer, ForeignKey('taxon.id', ondelete='SET NULL'), index=True)
     depth = Column(SmallInteger)
     parent = relationship('Taxon', foreign_keys='TaxonRelation.parent_id')
     child = relationship('Taxon', foreign_keys='TaxonRelation.child_id')


### PR DESCRIPTION
## Summary

Adds the three foreign-key indexes that PostgreSQL never created automatically. This is the fix for the current production slowdown.

`taxon_relation` is a closure table, so every taxon ancestry walk filters on `parent_id` / `child_id` — neither of which was indexed. Production diagnostics showed:

- **13,109,013 sequential scans** on `taxon_relation` (709,489 rows), against a `idx_scan` counter frozen at 608,581 that did not move at all during a live 30s sample
- ~90 million rows read per 30 seconds, roughly 3M rows/sec of pure waste
- **73% CPU steal** — the t3.large exhausted its burst credits and is being throttled to ~30% baseline, leaving ~0.6 usable vCPU
- Load average 12.85 with 370 queries over 5s in 25 minutes

## Commits

- `9aec01c` perf: add missing FK indexes on taxon_relation and unit

## Changes

**Models** — `index=True` on the unindexed FK columns:
- `app/models/taxon.py` — `TaxonRelation.parent_id`, `TaxonRelation.child_id`
- `app/models/collection.py` — `Unit.record_id`

**Migration** — `alembic/versions/d9e0f1a2b3c4_add_missing_fk_indexes.py` (revises `f7e8d9c0a1b2`)

## Deployment notes

The migration is written for a live production box:

- **`CREATE INDEX CONCURRENTLY`** inside an autocommit block — takes no write lock. `unit` is written continuously by the admin edit path, so a plain `CREATE INDEX` would block it.
- **`SET statement_timeout = 0`** — production caps statements at 30s. Without clearing it the build would be killed partway and leave an `INVALID` index behind, which is worse than no index.
- **`IF NOT EXISTS`** on both directions for idempotency across drifted environments.

Expect the build to be slow while the instance is still throttled.

## Verification

- `alembic upgrade head` → all three indexes created, version stamped
- `alembic downgrade -1` → all three dropped, back to `f7e8d9c0a1b2`
- `alembic upgrade head` → reapplied cleanly
- `alembic --autogenerate` → reports no drift for these three indexes, confirming names match SQLAlchemy's `ix_<table>_<column>`

## Not included

- A one-off `ANALYZE` was already run manually on production (`unit` had **never** been analyzed — planner estimated 1,374 rows against an actual 183,284). Statistics aren't schema, so that is not in this migration. Autovacuum on that host needs a separate ops fix.
- Pre-existing autogenerate drift on `unit_machine_transcription` / `unit_verbatim` indexes from `f7e8d9c0a1b2` — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)