### PR TITLE
ci: run alembic migrations during production deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,8 +14,23 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
+          # Abort on the first failing command. Without this a failed migration
+          # would be ignored and the restart below would still run, bringing up
+          # new code against an unmigrated schema.
+          script_stop: true
           script: |
             cd naturedb
             git pull origin main
+            # Migrate before restarting. The repo is bind-mounted at .:/code, so
+            # the pull above has already put new revisions inside the running
+            # container -- no rebuild needed. Ordering matters: on failure the
+            # old code keeps serving the old schema instead of restarting into a
+            # half-migrated state.
+            #
+            # NB: production runs with statement_timeout = 30s. A migration that
+            # does real work must "SET statement_timeout = 0" for its session or
+            # it will be killed partway through.
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic upgrade head"
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic current"
             #docker-compose -f compose.yml -f compose.prod.yml down && docker-compose -f compose.yml -f compose.prod.yml up --build -d
             sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml restart


### PR DESCRIPTION
## Summary

The production deploy only did `git pull` + `docker compose restart`. It never ran `alembic upgrade head`, so merging a PR shipped the migration *file* but not the schema change — a green Actions run looked like a successful deploy while the fix was entirely absent. Every migration in this repo's history has had to be applied by hand afterwards, including #139 and #140 earlier today.

## Changes

`.github/workflows/main.yml`:

- **`alembic upgrade head`** after the pull, before the restart
- **`alembic current`** logged so the deploy output records the resulting revision
- **`script_stop: true`** so the deploy aborts on the first failing command

## Why this ordering

The repo is bind-mounted at `.:/code`, so `git pull` already places new revisions inside the running container — no rebuild needed.

Migrating *before* the restart means a failed migration leaves the old code serving the old schema, rather than restarting into a half-migrated state. Without `script_stop`, a failed migration would be ignored and the restart would still run — the worst case.

## Note for future migrations

Production runs with `statement_timeout = 30s`. A migration doing real work must `SET statement_timeout = 0` for its session or it will be killed partway through. This is called out in a comment in the workflow.

## Verification

Both compose exec commands were run against production before committing:

```
$ sudo docker compose ... exec -T flask bash -c "cd /code && alembic current"
a3b5c7d9e1f2 (head)

$ sudo docker compose ... exec -T flask bash -c "cd /code && alembic upgrade head"
EXIT=0
```

YAML parses and `script_stop` is set. `-T` is required — there's no TTY in Actions.

## Not included

`.github/workflows/devel.yml` (staging) has the identical gap. Left alone since this PR was scoped to production, but staging is arguably where you'd want a bad migration to surface first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)