### PR TITLE
ci: use set -e instead of unsupported script_stop input

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,11 +14,13 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.KEY }}
-          # Abort on the first failing command. Without this a failed migration
-          # would be ignored and the restart below would still run, bringing up
-          # new code against an unmigrated schema.
-          script_stop: true
           script: |
+            # Abort on the first failing command. Without this a failed
+            # migration would be ignored and the restart below would still run,
+            # bringing up new code against an unmigrated schema. (Done with
+            # `set -e` rather than the action's script_stop input, which
+            # ssh-action v1.2.1 does not accept and silently ignores.)
+            set -e
             cd naturedb
             git pull origin main
             # Migrate before restarting. The repo is bind-mounted at .:/code, so


### PR DESCRIPTION
## Summary

Fixes a defect in #141. `appleboy/ssh-action@v1.2.1` does not accept a `script_stop` input — it was silently ignored and surfaced as an `Unexpected input(s)` annotation on the deploy run, so the intended abort-on-failure behaviour was **not actually in place**.

`set -e` at the top of the script achieves it in the shell, independent of what the action supports.

## Verification

Validated the workflow's `with:` keys against the action's documented input list:

```
YAML OK
script_stop present: False
invalid inputs: none
set -e present: True
```

The migration step itself was confirmed working on the real deploy run for #141:

```
INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
a3b5c7d9e1f2 (head)
 Container naturedb-flask-prod-container Restarting
```

Migration ran, revision logged, restart followed — correct ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)