### PR TITLE
ci: migrate via compose run --rm; add migrations to staging deploy

### DIFF
--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -23,16 +23,26 @@ jobs:
             cd ndb-staging
             git pull origin devel
             # Migrate before restarting. The repo is bind-mounted at .:/code, so
-            # the pull above has already put new revisions inside the running
-            # container -- no rebuild needed. `exec` targets the compose service
-            # name, not the container name, which matters here: staging runs
-            # WEB_ENV=prod, so its containers are also called
-            # naturedb-{flask,postgres}-prod-container.
+            # the pull above has already put new revisions inside the container
+            # image's mount -- no rebuild needed.
+            #
+            # `run --rm` rather than `exec`: exec needs the long-running app
+            # container to be healthy, and staging's flask container has been
+            # observed crash-looping, which made exec fail outright. It is also
+            # the case that an app can crash-loop *because* its schema is
+            # behind, deadlocking the one command that would fix it. run spins
+            # up a throwaway container from the same image and mounts, and its
+            # entrypoint waits for postgres. --no-deps keeps it from starting
+            # anything else, -T because there is no TTY in Actions.
+            #
+            # Targets the compose service name, not the container name, which
+            # matters here: staging runs WEB_ENV=prod, so its containers are
+            # also called naturedb-{flask,postgres}-prod-container.
             #
             # NB: if the server sets a statement_timeout, a migration doing real
             # work must "SET statement_timeout = 0" for its session or it will
             # be killed partway through.
-            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic upgrade head"
-            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic current"
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml run --rm --no-deps -T flask bash -c "cd /code && alembic upgrade head"
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml run --rm --no-deps -T flask bash -c "cd /code && alembic current"
             #docker-compose -f compose.yml -f compose.prod.yml down && docker-compose -f compose.yml -f compose.prod.yml up --build -d
             sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml restart

--- a/.github/workflows/devel.yml
+++ b/.github/workflows/devel.yml
@@ -15,7 +15,24 @@ jobs:
           username: ${{ secrets.DEVEL_USERNAME }}
           key: ${{ secrets.DEVEL_KEY }}
           script: |
+            # Abort on the first failing command, so a failed migration stops
+            # the deploy instead of restarting into an unmigrated schema.
+            # (`set -e` rather than the action's script_stop input, which
+            # ssh-action v1.2.1 does not accept and silently ignores.)
+            set -e
             cd ndb-staging
             git pull origin devel
+            # Migrate before restarting. The repo is bind-mounted at .:/code, so
+            # the pull above has already put new revisions inside the running
+            # container -- no rebuild needed. `exec` targets the compose service
+            # name, not the container name, which matters here: staging runs
+            # WEB_ENV=prod, so its containers are also called
+            # naturedb-{flask,postgres}-prod-container.
+            #
+            # NB: if the server sets a statement_timeout, a migration doing real
+            # work must "SET statement_timeout = 0" for its session or it will
+            # be killed partway through.
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic upgrade head"
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic current"
             #docker-compose -f compose.yml -f compose.prod.yml down && docker-compose -f compose.yml -f compose.prod.yml up --build -d
             sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml restart

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,15 +24,23 @@ jobs:
             cd naturedb
             git pull origin main
             # Migrate before restarting. The repo is bind-mounted at .:/code, so
-            # the pull above has already put new revisions inside the running
-            # container -- no rebuild needed. Ordering matters: on failure the
-            # old code keeps serving the old schema instead of restarting into a
-            # half-migrated state.
+            # the pull above has already put new revisions inside the container
+            # image's mount -- no rebuild needed. Ordering matters: on failure
+            # the old code keeps serving the old schema instead of restarting
+            # into a half-migrated state.
+            #
+            # `run --rm` rather than `exec`: exec needs the long-running app
+            # container to be healthy, but the app can be crash-looping
+            # *because* its schema is behind, which deadlocks the one command
+            # that would fix it. run spins up a throwaway container from the
+            # same image and mounts, and its entrypoint waits for postgres.
+            # --no-deps keeps it from starting anything else, -T because there
+            # is no TTY in Actions.
             #
             # NB: production runs with statement_timeout = 30s. A migration that
             # does real work must "SET statement_timeout = 0" for its session or
             # it will be killed partway through.
-            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic upgrade head"
-            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml exec -T flask bash -c "cd /code && alembic current"
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml run --rm --no-deps -T flask bash -c "cd /code && alembic upgrade head"
+            sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml run --rm --no-deps -T flask bash -c "cd /code && alembic current"
             #docker-compose -f compose.yml -f compose.prod.yml down && docker-compose -f compose.yml -f compose.prod.yml up --build -d
             sudo docker compose -f compose.yml -f compose.prod.yml -f compose.prod-vhosts.yml restart


### PR DESCRIPTION
## Summary

Completes the deploy-migration work from #141/#142 and extends it to staging.

## Changes

- **`devel.yml`** — staging now runs `alembic upgrade head`, same as production
- **Both workflows** — migrate via `docker compose run --rm --no-deps -T` instead of `exec`

## Why `run --rm` instead of `exec`

The first staging attempt failed with:

```
Error response from daemon: Container 2f8229d5... is restarting,
wait until the container is running
```

`exec` requires the long-running app container to be healthy. The general problem is worse than one unhealthy host: **an app can crash-loop precisely because its schema is behind, which deadlocks the one command that would fix it.** Migrations must not depend on the app container being up.

`run --rm --no-deps -T` starts a throwaway container from the same image with the same mounts and environment, and the image entrypoint already waits for postgres to accept connections.

Verified against production:

```
Container naturedb-flask-run-a22cfa00cfed Creating
PostgreSQL is available
a3b5c7d9e1f2 (head)
EXIT=0
```

No container left behind afterwards.

## This surfaced a real pre-existing failure on staging

With `run --rm`, the staging deploy got far enough to produce the actual error:

```
File "/code/app/helpers.py", line 4, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```

`requests==2.32.3` is in `requirements/base.txt`, so the repo is fine — **staging's flask image is stale**, built before that dependency landed. Neither workflow rebuilds (the `--build` line is commented out in both), so an image only picks up requirements changes when someone rebuilds by hand.

That means staging's app has been crash-looping and down, while every staging deploy reported success — `restart` never checks whether the container stays up.

**Staging deploys will keep failing until its flask image is rebuilt.** That is a pre-existing breakage this PR exposes rather than causes. Production is unaffected; its image is current and migrations run there cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)