### PR TITLE
config: move postgres tuning into compose, out of ALTER SYSTEM

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -29,6 +29,40 @@ services:
       - ../naturedb-volumes/logs/postgres:/var/log/postgresql
       - ./docker/postgresql.conf:/etc/postgresql.conf
       #command: -c config_file=/etc/postgresql.conf
+    # Postgres tuning lives here rather than in ALTER SYSTEM, so the repo is the
+    # single source of truth and a fresh environment reproduces production.
+    # Command-line `-c` outranks both postgresql.conf and postgresql.auto.conf,
+    # so these win over whatever initdb left inside the pgdata volume.
+    #
+    # Do NOT uncomment the config_file line above: pointing config_file at that
+    # 3-line file replaces the image's entire default config and drops
+    # listen_addresses, which breaks networking.
+    #
+    # Memory settings are env-driven because this file is shared by production
+    # and staging, which are not the same size. Defaults below are the stock
+    # PostgreSQL values, so an environment that sets nothing behaves exactly as
+    # it does today. Production (8 GiB) sets in its .env:
+    #   POSTGRES_SHARED_BUFFERS=2GB
+    #   POSTGRES_EFFECTIVE_CACHE_SIZE=6GB
+    #   POSTGRES_MAINTENANCE_WORK_MEM=256MB
+    # Rule of thumb: shared_buffers ~25% of RAM, effective_cache_size ~75%.
+    # Revisit both if the instance is ever resized.
+    command:
+      - postgres
+      - -c
+      - shared_buffers=${POSTGRES_SHARED_BUFFERS:-128MB}
+      - -c
+      - effective_cache_size=${POSTGRES_EFFECTIVE_CACHE_SIZE:-4GB}
+      - -c
+      - maintenance_work_mem=${POSTGRES_MAINTENANCE_WORK_MEM:-64MB}
+      # Not size-dependent, so pinned for every deployed environment.
+      # statement_timeout caps runaway queries (see the Jul 2026 incident); a
+      # migration or batch job doing real work must SET statement_timeout = 0
+      # for its own session.
+      - -c
+      - statement_timeout=30s
+      - -c
+      - log_autovacuum_min_duration=0
   redis:
     restart: always
 


### PR DESCRIPTION
## Summary

Postgres tuning on production lived in two files **inside the pgdata Docker volume**, neither in version control:

| setting | value | source |
|---|---|---|
| `shared_buffers` | 128MB | `pgdata/postgresql.conf` — initdb default, nobody set it |
| `statement_timeout` | 30s | `pgdata/postgresql.auto.conf` — `ALTER SYSTEM` |
| `log_autovacuum_min_duration` | 0 | `pgdata/postgresql.auto.conf` — `ALTER SYSTEM` |

A fresh environment built from this repo would not have reproduced production. Command-line `-c` outranks both `postgresql.conf` and `postgresql.auto.conf`, so declaring them in compose makes the repo the single source of truth.

## Why the memory settings are env-driven

`compose.prod.yml` is shared by production **and staging**, which are not the same size. A hardcoded `shared_buffers=2GB` could stop Postgres starting on a smaller box.

Defaults are the stock PostgreSQL values, so any environment that sets nothing behaves **exactly as it does today** — no surprise for staging. Production sets the tuned values in its `.env`:

```
POSTGRES_SHARED_BUFFERS=2GB
POSTGRES_EFFECTIVE_CACHE_SIZE=6GB
POSTGRES_MAINTENANCE_WORK_MEM=256MB
```

`statement_timeout` and `log_autovacuum_min_duration` are not size-dependent, so they're pinned for every deployed environment.

## Why 2GB

Production is 8 GiB with a **3.4 GB** database (`named_area` alone is 1.8 GB of PostGIS geometry). At 128MB, Postgres was caching almost nothing itself and leaning entirely on the OS page cache. Rule of thumb applied: `shared_buffers` ~25% of RAM, `effective_cache_size` ~75%.

## Verification

Rendered config substitutes correctly both ways:

- with env vars → `shared_buffers=2GB`, `effective_cache_size=6GB`, `maintenance_work_mem=256MB`
- without → `128MB` / `4GB` / `64MB` (stock defaults)

Booted locally with the production values; all five report the highest-precedence source:

```
 effective_cache_size        | 786432 | 8kB | command line
 log_autovacuum_min_duration | 0      | ms  | command line
 maintenance_work_mem        | 262144 | kB  | command line
 shared_buffers              | 262144 | 8kB | command line
 statement_timeout           | 30000  | ms  | command line
```

## Follow-up after merge

1. Add the three vars to production's `.env` (per-host config, like the existing secrets)
2. Restart Postgres so they take effect — brief downtime
3. Remove the two `ALTER SYSTEM` entries from `postgresql.auto.conf` so there is one source of truth rather than two silently competing

Also left alone deliberately: the inert `docker/postgresql.conf` mount. Uncommenting its `config_file` line would replace the image's entire default config and drop `listen_addresses`, breaking networking. Its `pg_stat_statements` settings could be moved onto this command line as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)