### PR TITLE
config: add log_min_duration_statement to compose postgres tuning

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -61,6 +61,11 @@ services:
       # for its own session.
       - -c
       - statement_timeout=30s
+      # Observability. log_min_duration_statement is what made the Jul 2026
+      # index regression diagnosable at all; log_autovacuum_min_duration was
+      # 10min by default, which hid every autovacuum run that mattered.
+      - -c
+      - log_min_duration_statement=5s
       - -c
       - log_autovacuum_min_duration=0
   redis:


### PR DESCRIPTION
## Summary

Missed in #144. Production's `postgresql.auto.conf` also carried a third setting:

```
statement_timeout = '30s'
log_min_duration_statement = '5000'      <-- this one
log_autovacuum_min_duration = '0'
```

`log_min_duration_statement=5s` is the slow-query log set during the July 2026 incident — it is what made this month's missing-index regression diagnosable at all (370 queries over 5s in 25 minutes was the signal that led to `taxon_relation`).

Resetting `auto.conf` to leave compose as the single source of truth, as #144 planned, would have **silently disabled it**. Declaring it in compose first.

## Verification

Rendered config now shows all six:

```
- shared_buffers=128MB          (2GB on prod via .env)
- effective_cache_size=4GB      (6GB on prod via .env)
- maintenance_work_mem=64MB     (256MB on prod via .env)
- statement_timeout=30s
- log_min_duration_statement=5s
- log_autovacuum_min_duration=0
```

## Note on the deploy

`docker compose restart` does **not** re-read compose changes — it restarts existing containers with their existing config. Applying a changed `command:` needs `up -d` to recreate the container. #144's settings did not take effect until I ran that by hand.

That is the same class of gap as the migrations one fixed in #141: the deploy silently doesn't do what it looks like it does. Worth changing `restart` to `up -d` in both workflows as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)